### PR TITLE
Adding Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 venv3/
 .idea/
 package-lock.json
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.7-slim-buster
+
+LABEL Author="Daniel Guddemi danguddemi@gmail.com"
+
+RUN apt-get update -y &&\
+    apt-get install -y git g++ gcc libxslt-dev libc-dev ffmpeg
+
+COPY ./requirements.txt /songflong/requirements.txt
+
+WORKDIR /songflong
+
+RUN pip install -r requirements.txt
+
+COPY ./run.py /songflong/run.py
+COPY ./worker.py /songflong/worker.py
+COPY ./app /songflong/app
+
+ENTRYPOINT [ "python" ]
+CMD [ "run.py" ]

--- a/Dockerfile.dashboard
+++ b/Dockerfile.dashboard
@@ -1,0 +1,7 @@
+FROM python:3.7.0-alpine
+
+RUN pip install rq-dashboard
+
+EXPOSE 9181
+
+CMD ["rq-dashboard"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SongFlong
 
 ## Setup
-*SongFlong is built to run instead a Docker swarm and routing issues can occur if ran locally.*
+*SongFlong is built to run inside a Docker swarm and routing issues can occur if ran locally.*
 
 To run it locally, you need to manually replace the hostname of the Redis connection. This has to be done for the main Flask app and for the Worker. Changing it to `localhost` should suffice.
 
@@ -10,5 +10,5 @@ To run it using Docker, all you need to do is install Docker and Docker-Compose.
 docker-compose up --build --scale worker=3
 ```
 
-The `--build` flag is not necessary.
+The `--build` flag is not necessary; it does stuff that I don't feel like explaining to David (just look it up).
 The `--scale` can be modified to replicate as many workers as you want. Removing it completely will default to just 1.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
-## Bug Fixes
-*Sorry David*
+# SongFlong
 
-There are bugs in the 9.5.2 version of "pytube". You need to install the requirement and then manually implement the fixes in the files. They're are located in the virtualenv/lib/python3.7/site-packages/pytube
-https://github.com/nficano/pytube/pull/453/files/fac934b149bc2d49ea54d566e0639d9b4c2862d2
+## Setup
+*SongFlong is built to run instead a Docker swarm and routing issues can occur if ran locally.*
+
+To run it locally, you need to manually replace the hostname of the Redis connection. This has to be done for the main Flask app and for the Worker. Changing it to `localhost` should suffice.
+
+To run it using Docker, all you need to do is install Docker and Docker-Compose.
+```
+docker-compose up --build --scale worker=3
+```
+
+The `--build` flag is not necessary.
+The `--scale` can be modified to replicate as many workers as you want. Removing it completely will default to just 1.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,8 +7,9 @@ from rq import Queue
 
 def create_app():
     app = Flask(__name__, static_folder="../temp")
-    app.config["FFMPEG_PATH"] = os.environ.get("FFMPEG_PATH", default="/usr/bin/ffmpeg")
-    app.q = Queue(connection=StrictRedis())
+    app.config["FFMPEG_PATH"] = os.environ.get(
+        "FFMPEG_PATH", default="/usr/bin/ffmpeg")
+    app.q = Queue(connection=StrictRedis(host='redis', port='6379'))
     from app.routes import JOBS
     app.register_blueprint(JOBS)
     return app

--- a/app/songflong/__init__.py
+++ b/app/songflong/__init__.py
@@ -1,6 +1,8 @@
 import logging
 
-logging.basicConfig(level=logging.INFO,
-                    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+log_format = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+handler = logging.StreamHandler()
+handler.setLevel(logging.INFO)
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('songflong_builder')
+logger.addHandler(handler)

--- a/app/songflong/download.py
+++ b/app/songflong/download.py
@@ -5,10 +5,7 @@ from math import ceil
 import requests
 import logging
 
-logging.basicConfig(level=logging.INFO,
-                    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('songflong_builder')
 
 
 def download_stream(video_url, itag, download_dir):
@@ -77,8 +74,9 @@ def download_audio_stream(url: str, download_dir: Path) -> Path:
     try:
         logger.info(f"Downloading audio stream -> {url}")
         return download_stream(url, 140, download_dir)
-    except:
+    except Exception as err:
         logger.error(f"Unable to find an audio stream for {url}")
+        logger.exception(err)
 
 
 def download_video_stream(url: str, download_dir: Path) -> Path:

--- a/app/songflong/ffmpeg.py
+++ b/app/songflong/ffmpeg.py
@@ -4,7 +4,9 @@ import os
 import subprocess as sp
 import proglog
 from flask import current_app
+import logging
 
+logger = logging.getLogger('songflong_builder')
 
 def subprocess_call(cmd):
     """
@@ -48,7 +50,12 @@ def ffmpeg_merge_video_audio(video: Path, audio: Path, output: Path, ffmpeg_path
     :param output: The destination Path for the merged movie file
     :param output: Path
     """
+    
     cmd = [ffmpeg_path, "-y", "-i", str(audio), "-i", str(video),
            "-vcodec", 'copy', "-acodec", 'copy', str(output)]
 
-    subprocess_call(cmd)
+    try:
+        subprocess_call(cmd)
+    except Exception as err:
+        logger.warning(f"Merging audio:{str(audio)} and video:{str(video)} to output{str(output)}")
+        logger.error(err)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+version: '3.3'
+
+services: 
+
+  songflong:
+    build: .
+    image: songflong
+    container_name: songflong
+    entrypoint: python
+    command: run.py
+    ports:
+      - '5000:5000'
+    environment:
+      - FLASK_DEBUG=True
+      - FFMPEG_PATH=/usr/bin/ffmpeg
+    volumes: 
+      - temp:/songflong/temp
+    depends_on: 
+      - redis
+
+  worker:
+    image: songflong
+    command: worker.py
+    environment:
+      - FFMPEG_PATH=/usr/bin/ffmpeg
+    volumes: 
+      - temp:/songflong/temp
+    depends_on: 
+      - redis
+  
+  redis:
+    image: redis
+    container_name: redis
+    ports:
+      - "6379:6379"
+
+  dashboard:
+    build:
+      context: .
+      dockerfile: Dockerfile.dashboard
+    image: dashboard
+    container_name: dashboard
+    ports:
+      - '9181:9181'
+    command: rq-dashboard -H redis
+
+volumes:
+  temp:

--- a/run.py
+++ b/run.py
@@ -1,6 +1,8 @@
 from app import create_app
+from rq import Worker
+
 
 app = create_app()
 
-if __name__ == '__main__':
-    app.run(host="10.60.163.239", debug=True)
+if __name__ == "__main__":
+    app.run(host='0.0.0.0', port='5000', debug=False)

--- a/worker.py
+++ b/worker.py
@@ -1,0 +1,9 @@
+import redis
+from rq import Worker, Connection
+
+conn = redis.from_url('redis://redis:6379')
+
+if __name__ == '__main__':
+    with Connection(conn):
+        worker = Worker(['default'])
+        worker.work()


### PR DESCRIPTION
## Changes
- Added a Dockerfile to build a `songflong` image for the Flask app
- Added a Dockerfile for the RQ Dashboard
- Added a worker.py script for the spawning of RQ workers
- Modified some of the logging in the SongFlong app (further work still needed)
- Updated the README to actually be helpful
- Reset the Flask app to `0.0.0.0:5000` and defaulted to `debug=False`
- Reset the Redis hostname to `redis` to enable easier name resolution in a Docker Swarm. **This breaks the app when running it outside of docker. (A fix is listed in the README)**